### PR TITLE
Closes #89 - calls join in db instead of allRestaurants for the GET to /wait

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -8,7 +8,7 @@ app.get('/wait', function (req, res) {
   // This will eventually ask the database for the wait times from all restaurants
   // and then send them back to Angular.
 
-  db.getAllRestaurants (function (results){
+  db.getAvgWaitsLatestReportAllLocs (function (results){
     res.send(results);
   })
 });


### PR DESCRIPTION
The allRestaurants( ) method wasn't returning the info we wanted from the db. I switched it to use the join instead, which is returning this format for a GET request to /wait:

```
[
    {
        "google_id": "ChIJ-b18sKC1RIYRiDl8W83nAW0",
        "name": "Austin Club",
        "avg_wait": 10,
        "most_recent": "2015-04-16T15:25:25.000Z"
    },
    {
        "google_id": "ChIJ-yElAAq1RIYRiJYnsvPyhUY",
        "name": "Subway",
        "avg_wait": 5,
        "most_recent": "2015-04-16T15:25:25.000Z"
    },
    {
        "google_id": "ChIJoQKzBAq1RIYR9vDjI9c6QZs",
        "name": "Jimmy John's",
        "avg_wait": 30,
        "most_recent": "2015-04-16T15:25:25.000Z"
    }
]
```
